### PR TITLE
Fix hardcoded layer collection processing

### DIFF
--- a/nng/regression/misc/collections.py
+++ b/nng/regression/misc/collections.py
@@ -8,6 +8,13 @@ _FLAGS = {}
 def add_to_collection(key, value):
     _FLAGS[key] = value
 
-
 def get_collection(key):
     return _FLAGS[key]
+
+def get_layer_input_activations(n_layers):
+    for i in range(n_layers):
+        yield get_collection("a{}".format(i))
+
+def get_layer_outputs(n_layers):
+    for i in range(n_layers):
+        yield get_collection("s{}".format(i))

--- a/nng/regression/misc/layers.py
+++ b/nng/regression/misc/layers.py
@@ -10,11 +10,9 @@ from nng.regression.misc.kl_utils import *
 from nng.regression.controller.distributions import *
 
 
-def _append_homog(tensor):
-    rank = len(tensor.shape.as_list())
-    shape = tf.concat([tf.shape(tensor)[:-1], [1]], axis=0)
-    ones = tf.ones(shape, dtype=tensor.dtype)
-    return tf.concat([tensor, ones], axis=rank - 1)
+def append_homog(x: tf.Tensor) -> tf.Tensor:
+    ones = tf.ones(tf.concat([tf.shape(x)[:-1], [1]], axis=0))
+    return tf.concat([x, ones], axis=-1)
 
 
 class Layer(object):

--- a/nng/regression/model.py
+++ b/nng/regression/model.py
@@ -9,7 +9,8 @@ from tensorflow.contrib.framework import with_shape
 from nng.core.base_model import BaseModel
 from nng.misc.registry import get_model
 from nng.regression.controller.bayesian_learning import BayesianLearning
-from nng.regression.misc.collections import get_collection
+from nng.regression.misc.collections import (
+    get_collection, get_layer_input_activations, get_layer_outputs)
 from nng.regression.misc.layers import append_homog, EMVGLayer, MVGLayer
 from nng.regression.controller.sample import NormalOutSample
 import nng.regression.network.ffn as ffn
@@ -245,11 +246,12 @@ class Model(BaseModel):
                 tf.shape(self.inputs)[0], tf.float32)
         w_grads = tf.gradients(self._log_py_xw / n_batches, qws)
 
-        activations = [get_collection("a0"), get_collection("a1")]
-        activations = [append_homog(activation)
-                       for activation in activations]
+        n_layers = len(layers)
+        activations = [append_homog(a)
+                       for a in get_layer_input_activations(n_layers)]
+        s = list(get_layer_outputs(n_layers))
+        assert len(layers) == len(activations) == len(s)
 
-        s = [get_collection("s0"), get_collection("s1")]
         if self.stub == "regression":
             if self.config.true_fisher and self.stub == "regression":
                 # True fisher: sample model and y from the var. distribution.

--- a/nng/regression/model.py
+++ b/nng/regression/model.py
@@ -9,7 +9,8 @@ from tensorflow.contrib.framework import with_shape
 from nng.core.base_model import BaseModel
 from nng.misc.registry import get_model
 from nng.regression.controller.bayesian_learning import BayesianLearning
-from nng.regression.misc.layers import *
+from nng.regression.misc.collections import get_collection
+from nng.regression.misc.layers import append_homog, EMVGLayer, MVGLayer
 from nng.regression.controller.sample import NormalOutSample
 import nng.regression.network.ffn as ffn
 
@@ -245,9 +246,8 @@ class Model(BaseModel):
         w_grads = tf.gradients(self._log_py_xw / n_batches, qws)
 
         activations = [get_collection("a0"), get_collection("a1")]
-        activations = [tf.concat(
-            [activation,
-             tf.ones(tf.concat([tf.shape(activation)[:-1], [1]], axis=0))], axis=-1) for activation in activations]
+        activations = [append_homog(activation)
+                       for activation in activations]
 
         s = [get_collection("s0"), get_collection("s1")]
         if self.stub == "regression":


### PR DESCRIPTION
The train_op construction assumed 2 layers always. My previous patches for arbitrary layers forgot to modify train_op construction. This led to errors when constructing a net with only 1 layer, and silent fails when constructing a net with more than 2 layers.

This is what fitting a random SimpleProblem looks like right now:
![image](https://user-images.githubusercontent.com/1750835/55047283-70d97680-5001-11e9-81f1-58e4c3049227.png)
